### PR TITLE
Fix warnings 'shadowing outer local variable - al'

### DIFF
--- a/lib/unicode_utils/sid.rb
+++ b/lib/unicode_utils/sid.rb
@@ -7,12 +7,12 @@ module UnicodeUtils
 
   CP_PREFERRED_ALIAS_STRING_MAP = Hash.new.tap do |map|
     NAME_ALIASES_MAP.each { |cp, aliases|
-      al =
+      found_alias =
         (aliases.find { |al| al.type == :correction } ||
          aliases.find { |al| al.type == :control } ||
          aliases.find { |al| al.type == :figment } ||
          aliases.find { |al| al.type == :alternate })
-      map[cp] = al.name if al
+      map[cp] = found_alias.name if found_alias
     }
   end #:nodoc:
 


### PR DESCRIPTION
I get those warnings when I include the gem and run a program e.g. through xmpfilter.
Same with ruby -W2.
