### PR TITLE
Binary to quick lookup symbols by their names.

### DIFF
--- a/bin/uc_grep
+++ b/bin/uc_grep
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+
+lib = File.expand_path(File.dirname(__FILE__) + '/../lib')
+$LOAD_PATH.unshift(lib) if File.directory?(lib) && !$LOAD_PATH.include?(lib)
+
+require 'optparse'
+require 'unicode_utils/grep'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{$0} [options] NAME"
+
+  # Output style
+  opts.on("-o", "--out TYPE", [:full, :symbol],
+          "Output style (full, symbol); default: full") do |type|
+    options[:type] = type
+  end
+  # Use hunspell to suggest?
+  opts.on("-s", "--suggest", "Suggest results for misspelled words using hunspell; default: false") do |suggest|
+    options[:suggest] = suggest
+  end
+  # No argument, shows at tail.  This will print an options summary.
+  opts.on_tail("-h", "--help", "Show this message") do
+    puts opts
+    exit
+  end
+end.parse!
+
+raise "Run `#{$0} --help` for execution examples. Exiting…" if ARGV.size.zero?
+
+options[:type] ||= :full
+text = ARGV.first
+
+def print_results word, full=true
+  puts '='*40
+  puts "Trying #{word}…"
+  vars = UnicodeUtils.grep(/#{word}/)
+  unless vars.size.zero?
+    vars.each { |res|
+      full ? puts("⇒  [#{res.inspect}]") : print(" #{res} ")
+    }
+    puts
+  end
+  vars.size > 0
+end
+
+found = case options[:type]
+when :symbol
+  print_results text, false
+when :full
+  print_results text
+end
+
+if options[:suggest]
+  spellchecker = begin
+                   require 'Hunspell' 
+                 rescue LoadError
+                   false
+                 end
+  unless spellchecker
+    puts 'You seem to lack hunspell gem required for suggestive mode.'
+    puts 'Try to install libhunspell, libhunspell-dev and hunspell gem:'
+    puts '  $ sudo aptitude install libhunspell libhunspell-dev # Ubuntu example'
+    puts '  $ gem install hunspell'
+    exit 1
+  end
+
+  dict = `echo | hunspell -D 2>&1 | grep en_US`.split("\n").first || \
+         '/usr/share/hunspell/en_US'
+  sp = Hunspell.new("#{dict}.aff", "#{dict}.dic")
+  sp.suggest(text).each { |suggest|
+    print_results suggest, options[:type] != :symbol
+  }
+else
+  puts "No results… Try to use “-s” option for suggestions?" unless found
+end


### PR DESCRIPTION
This is just a handy utility to lookup symbols from the command line using the power of `unicode_utils`.

E. g.:

```
$ uc_grep --help
Usage: uc_grep [options] NAME
    -o, --out TYPE                   Output style (full, symbol); default: full
    -s, --suggest                    Suggest results for misspelled words using hunspell; default: false
    -h, --help                       Show this message

$ uc_grep suit
========================================
Trying suit…
⇒  [#<U+2660 "♠" BLACK SPADE SUIT utf8:e2,99,a0>]
⇒  [#<U+2661 "♡" WHITE HEART SUIT utf8:e2,99,a1>]
⇒  [#<U+2662 "♢" WHITE DIAMOND SUIT utf8:e2,99,a2>]
⇒  [#<U+2663 "♣" BLACK CLUB SUIT utf8:e2,99,a3>]
⇒  [#<U+2664 "♤" WHITE SPADE SUIT utf8:e2,99,a4>]
⇒  [#<U+2665 "♥" BLACK HEART SUIT utf8:e2,99,a5>]
⇒  [#<U+2666 "♦" BLACK DIAMOND SUIT utf8:e2,99,a6>]
⇒  [#<U+2667 "♧" WHITE CLUB SUIT utf8:e2,99,a7>]
⇒  [#<U+329C "㊜" CIRCLED IDEOGRAPH SUITABLE utf8:e3,8a,9c>]

$ uc_grep -o symbol suit
========================================
Trying suit…
 ♠  ♡  ♢  ♣  ♤  ♥  ♦  ♧  ㊜ 
```
