### PR TITLE
Don't ship test files in the gem artifact + cleanup

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,7 +9,7 @@ New methods in UnicodeUtils:
 * white_space_char?
 
 All tests pass with jruby-1.7.0.RC1. Not all tests pass with
-MRI 1.9.3p194 due to unexptected behaviour of String#<< with
+MRI 1.9.3p194 due to unexpected behaviour of String#<< with
 UTF-16 strings. As long as you use only UTF-8, there's no problem.
 
 == 1.3.0, 2012-03-07

--- a/ISSUES.txt
+++ b/ISSUES.txt
@@ -24,7 +24,7 @@ Possible course of action:
 
 == Encoding of string property values
 
-The encoding of spring property values is currenctly undocumented.
+The encoding of spring property values is currently undocumented.
 
 Possible course of action:
 * Use the same encoding for all string property values, preferably UTF-8

--- a/README.rdoc
+++ b/README.rdoc
@@ -9,7 +9,7 @@ Install with RubyGems:
 
     gem install unicode_utils
 
-Or get the source from Github: http://github.com/lang/unicode_utils
+Or get the source from GitHub: https://github.com/lang/unicode_utils
 and follow the instructions in INSTALL.txt.
 
 UnicodeUtils works with Ruby 1.9.1 or later.
@@ -17,7 +17,7 @@ UnicodeUtils works with Ruby 1.9.1 or later.
 == Synopsis
 
     require "unicode_utils/upcase"
-    
+
     UnicodeUtils.upcase("weiß") => "WEISS"
 
     UnicodeUtils.upcase("i", :tr) => "İ"
@@ -32,10 +32,8 @@ LICENSE.txt in the unicode_utils package for details.
 
 == Links
 
-Online documentation:: http://unicode-utils.rubyforge.org
-Source code:: http://github.com/lang/unicode_utils
-Rubyforge project:: http://rubyforge.org/projects/unicode-utils
-Home of the Unicode Consortium:: http://unicode.org
+Source code:: https://github.com/lang/unicode_utils
+Home of the Unicode Consortium:: http://unicode.org/
 
 == Who?
 

--- a/unicode_utils.gemspec
+++ b/unicode_utils.gemspec
@@ -2,9 +2,8 @@
 
 require "#{File.dirname(__FILE__)}/lib/unicode_utils/version"
 
-test_files = ["test/test_unicode_utils.rb"]
 files =
-  Dir["lib/**/*.rb"] + Dir["cdata/*"] + test_files +
+  Dir["lib/**/*.rb"] + Dir["cdata/*"] +
   ["README.rdoc", "INSTALL.txt", "LICENSE.txt", "CHANGES.txt"]
 files.reject! { |fn| fn.end_with?("~") }
 
@@ -12,16 +11,14 @@ Gem::Specification.new do |g|
   g.name = "unicode_utils"
   g.version = UnicodeUtils::VERSION
   g.platform = Gem::Platform::RUBY
-  g.summary = "additional Unicode aware functions for Ruby 1.9"
+  g.summary = "Additional Unicode aware functions for Ruby 1.9+."
   g.require_paths = ["lib"]
   g.files = files
-  g.test_files = test_files
   g.required_ruby_version = ">= 1.9.1"
   g.author = "Stefan Lang"
   g.email = "langstefan@gmx.at"
-  g.has_rdoc = true
   g.extra_rdoc_files = ["README.rdoc", "INSTALL.txt", "CHANGES.txt"]
   g.rdoc_options = ["--main=README.rdoc", "--charset=UTF-8"]
-  g.homepage = "http://github.com/lang/unicode_utils"
+  g.homepage = "https://github.com/lang/unicode_utils"
   g.rubyforge_project = "unicode-utils"
 end


### PR DESCRIPTION
There's no need to ship the test artifact in the gem. It only makes ruby
installs larger. This removes that and fixes some typos / URLs.

Signed-off-by: Tim Smith <tsmith@chef.io>