### PR TITLE
Fix for #6 (long initialization of unicode_utils)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Session.vim
 .test-result
 /coverage
 /aux
+.idea

--- a/lib/unicode_utils/read_cdata.rb
+++ b/lib/unicode_utils/read_cdata.rb
@@ -72,10 +72,15 @@ module UnicodeUtils
     def self.read_names(filename)
       Hash.new.tap { |map|
         open_cdata_file(filename) do |input|
-          buffer = "x" * 6
-          buffer.force_encoding(Encoding::US_ASCII)
-          while input.read(6, buffer)
-            map[buffer.to_i(16)] = input.gets.tap { |x| x.chomp! }
+          line = ""
+          line.force_encoding(Encoding::US_ASCII)
+          buffer = input.gets
+          while buffer
+            line.replace(buffer)
+            keycode = line[0..5].to_i(16)
+            keyname = line[6..-1]
+            map[keycode] = keyname.tap { |x| x.chomp! }
+            buffer = input.gets
           end
         end
       }


### PR DESCRIPTION
This fixes the long initialization on Windows 7. Maybe you could add a conditional for other OSes or check if this doesn't influence them.