### PR TITLE
gemspec: add SPDX compatible license metadata

### DIFF
--- a/unicode_utils.gemspec
+++ b/unicode_utils.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |g|
   g.rdoc_options = ["--main=README.rdoc", "--charset=UTF-8"]
   g.homepage = "http://github.com/lang/unicode_utils"
   g.rubyforge_project = "unicode-utils"
+  s.license = "BSD-2-Clause"
 end


### PR DESCRIPTION
so it can be used by compliance tools properly

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>