### PR TITLE
[F] remove unused var c0. Avoid linter warnings.

### DIFF
--- a/lib/unicode_utils/each_grapheme.rb
+++ b/lib/unicode_utils/each_grapheme.rb
@@ -34,7 +34,6 @@ module UnicodeUtils
   #   UnicodeUtils.each_grapheme("a\r\nb").count => 3
   def each_grapheme(str)
     return enum_for(__method__, str) unless block_given?
-    c0 = nil
     c0_prop = nil
     grapheme = String.new.force_encoding(str.encoding)
     str.each_codepoint { |c|
@@ -77,7 +76,6 @@ module UnicodeUtils
         grapheme = String.new.force_encoding(str.encoding)
       end
       grapheme << c
-      c0 = c
       c0_prop = c_prop
     }
     yield grapheme unless grapheme.empty?


### PR DESCRIPTION
Running my project test appears this warning:

```
/home/quigon/.rbenv/versions/3.1.0/lib64/ruby/gems/3.1.0/gems/unicode_utils-1.4.0/lib/unicode_utils/each_grapheme.rb:37: warning: assigned but unused variable - c0
Loaded suite /home/quigon/.rbenv/versions/3.1.0/lib64/ruby/gems/3.1.0/gems/rake-13.0.6/lib/rake/rake_test_loader
Started
```

My suggestion is delete lines with `c0` var, This var isn't used.

Thanks!